### PR TITLE
Correcting whoami endpoint and handling updated sync case

### DIFF
--- a/lib/SmallBot.ts
+++ b/lib/SmallBot.ts
@@ -124,7 +124,11 @@ export class SmallBot {
                 (since ? ("since=" + since) : ""),
             ]
         );
-        response.rooms.join = new Map<string, MatrixRoomEvent>(Object.entries(response.rooms.join));
+        if (response.rooms && response.rooms.join) {
+            response.rooms.join = new Map<string, MatrixRoomEvent>(Object.entries(response.rooms.join));
+        } else {
+            response.rooms = {join: new Map<string, MatrixRoomEvent>()};
+        }
         return response;
     }
 

--- a/lib/SmallBot.ts
+++ b/lib/SmallBot.ts
@@ -132,7 +132,7 @@ export class SmallBot {
      * Returns the `MatrixWhoAmIResponse` containing the userId of the bot
      */
     async whoAmI() {
-        return await this.doRequest<MatrixWhoAmIResponse>("whoami", []);
+        return await this.doRequest<MatrixWhoAmIResponse>("account/whoami", []);
     }
 
     /**


### PR DESCRIPTION
[The documentation for `/sync`](https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-sync) does not require that `rooms` be returned. From testing on the https://matrix-client.matrix.org homeserver, this seems to happen in cases where there are no new updates. Without handling, the program crashes immediately after coming up-to-date.

Additionally, the `/whoami` endpoint was reaching for `/_matrix/client/r0/whoami` instead of the `/_matrix/client/r0/account/whoami` [described in the documentation](https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-account-whoami).